### PR TITLE
Fix bug with process being undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,10 @@ module.exports = {
         {
           match: /exports\.([a-zA-Z0-9]+) = function \(/g,
           replacement: 'exports.$1 = function $1 ('
+        },
+        {
+          match: /process\.nextTick/g,
+          replacement: 'Ember.run.next'
         }
       ]
     })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where `process` was undefined by replacing `process.nextTick` with `Ember.run.later`.

