### PR TITLE
Upgrade to latest z-schema

### DIFF
--- a/blueprints/ember-z-schema/index.js
+++ b/blueprints/ember-z-schema/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
     return this.addPackagesToProject([
-      {name: 'z-schema', target: '3.17.0'}
+      {name: 'z-schema', target: '3.18.1'}
     ])
       .then(() => {
         return this.addAddonsToProject({

--- a/index.js
+++ b/index.js
@@ -77,6 +77,10 @@ module.exports = {
           replacement: 'var _ = require($2lodash$4);\nvar $1 = _.$3'
         },
         {
+          match: /= _\.isequal/g,
+          replacement: '= _.isEqual'
+        },
+        {
           match: /require\(("|')([^"']+)\.json("|')\)/g,
           replacement: 'require($1$2$3)'
         }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-resolver": "^2.0.3",
     "ember-validator-shim": "^1.0.0",
     "eslint": "^3.2.2",
-    "eslint-config-frost-standard": "^3.0.0",
+    "eslint-config-frost-standard": "^4.0.0",
     "loader.js": "^4.0.11",
     "lodash-es": "4.15.0",
     "remark-cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "remark-cli": "^1.0.0",
     "remark-lint": "^4.2.0",
     "validator": "5.5.0",
-    "z-schema": "3.17.0"
+    "z-schema": "3.18.1"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** shim to work with `z-schema` version `3.18.1` and updated blueprint to install that version.

