### PR TITLE
Fix included binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@
 module.exports = {
   name: 'z-schema',
 
-  included (parent) {
-    this._super.included(parent)
+  included () {
+    this._super.included.apply(this, arguments)
 
     this.import({
       development: 'vendor/z-schema/z-schema.js',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "Matthew Dahl (https://github.com/sandersky)",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "^0.3.2",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-z-schema/issues/92

# CHANGELOG
* **Updated** super call inside of `included` hook of `index.js` to bind the context to `this`